### PR TITLE
Update environment variable injection for oneAPI setup

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Install Intel oneAPI compilers
         uses: ./
         with:
-          install-classic: false
+          install-classic: true
           install-oneapi: true
           oneapi-version: ${{ matrix.version }}
           compiler-setup: 'oneapi'

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -28,7 +28,8 @@ jobs:
         with:
           install-classic: true
           classic-version: ${{ matrix.version }}
-          install-oneapi: false
+          install-oneapi: true
+          oneapi-version: 2025.3
           compiler-setup: 'classic'
           env-update: true
           cache: false

--- a/action.yml
+++ b/action.yml
@@ -145,18 +145,13 @@ runs:
       run: |
         # Inject environment changes into $GITHUB_ENV
         echo 'Updating $GITHUB_ENV'
+        bash -c "env > /tmp/before.txt"
         if [ "${{ inputs.compiler-setup }}" == "oneapi" ]; then
           echo -e "CC=icx\nCXX=icpx\nFC=ifx" >> $GITHUB_ENV
-          bash -c "env > /tmp/before.txt"
-          bash -c ". /opt/intel/oneapi/compiler/${{ inputs.oneapi-version }}/env/vars.sh && env > /tmp/after.txt"
-          diff --unchanged-line-format= --old-line-format= --new-line-format='%L' /tmp/before.txt /tmp/after.txt > /tmp/update.txt || true
-          cat /tmp/update.txt |& tee -a $GITHUB_ENV
+          bash -c ". /opt/intel/oneapi/compiler/${{ inputs.oneapi-version }}/env/vars.sh && env >> /tmp/after.txt"
         elif [ "${{ inputs.compiler-setup }}" == "classic" ]; then
           echo -e "CC=icc\nCXX=icpc\nFC=ifort" >> $GITHUB_ENV
-          bash -c "env > /tmp/before.txt"
-          bash -c ". /opt/intel/oneapi/compiler/${{ inputs.classic-version }}/env/vars.sh && env > /tmp/after.txt"
-          diff --unchanged-line-format= --old-line-format= --new-line-format='%L' /tmp/before.txt /tmp/after.txt > /tmp/update.txt || true
-          cat /tmp/update.txt |& tee -a $GITHUB_ENV
+          bash -c ". /opt/intel/oneapi/compiler/${{ inputs.classic-version }}/env/vars.sh && env >> /tmp/after.txt"
         fi
         if [ "${{ inputs.mpi-wrapper-setup }}" == "oneapi" ]; then
           echo -e "CC=mpiicx\nCXX=mpiicpx\nFC=mpiifx" >> $GITHUB_ENV
@@ -165,7 +160,12 @@ runs:
           echo -e "CC=mpiicc\nCXX=mpiicpc\nFC=mpiifort" >> $GITHUB_ENV
           echo -e "I_MPI_CC=icc\nI_MPI_CXX=icpc\nI_MPI_FC=ifort\nI_MPI_F77=ifort" >> $GITHUB_ENV
         fi
+        if [ "${{ inputs.install-mkl }}" == true ]; then
+          bash -c ". /opt/intel/oneapi/mkl/${{ inputs.mkl-version }}/env/vars.sh && env >> /tmp/after.txt"
+        fi
         echo "CI_INTEL_CLASSIC_VERSION=${{ inputs.classic-version }}" >> $GITHUB_ENV
         echo "CI_INTEL_ONEAPI_VERSION=${{ inputs.oneapi-version }}" >> $GITHUB_ENV
         echo "CI_INTEL_MPI_VERSION=${{ inputs.mpi-version }}" >> $GITHUB_ENV
         echo "CI_INTEL_MKL_VERSION=${{ inputs.mkl-version }}" >> $GITHUB_ENV
+        diff --unchanged-line-format= --old-line-format= --new-line-format='%L' /tmp/before.txt /tmp/after.txt > /tmp/update.txt || true
+        cat /tmp/update.txt |& tee -a $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -145,14 +145,18 @@ runs:
       run: |
         # Inject environment changes into $GITHUB_ENV
         echo 'Updating $GITHUB_ENV'
-        bash -c "env > /tmp/before.txt"
-        bash -c ". /opt/intel/oneapi/setvars.sh && env > /tmp/after.txt"
-        diff --unchanged-line-format= --old-line-format= --new-line-format='%L' /tmp/before.txt /tmp/after.txt > /tmp/update.txt || true
-        cat /tmp/update.txt |& tee -a $GITHUB_ENV
         if [ "${{ inputs.compiler-setup }}" == "oneapi" ]; then
           echo -e "CC=icx\nCXX=icpx\nFC=ifx" >> $GITHUB_ENV
+          bash -c "env > /tmp/before.txt"
+          bash -c ". /opt/intel/oneapi/compiler/${{ inputs.oneapi-version }}/env/vars.sh && env > /tmp/after.txt"
+          diff --unchanged-line-format= --old-line-format= --new-line-format='%L' /tmp/before.txt /tmp/after.txt > /tmp/update.txt || true
+          cat /tmp/update.txt |& tee -a $GITHUB_ENV
         elif [ "${{ inputs.compiler-setup }}" == "classic" ]; then
           echo -e "CC=icc\nCXX=icpc\nFC=ifort" >> $GITHUB_ENV
+          bash -c "env > /tmp/before.txt"
+          bash -c ". /opt/intel/oneapi/compiler/${{ inputs.classic-version }}/env/vars.sh && env > /tmp/after.txt"
+          diff --unchanged-line-format= --old-line-format= --new-line-format='%L' /tmp/before.txt /tmp/after.txt > /tmp/update.txt || true
+          cat /tmp/update.txt |& tee -a $GITHUB_ENV
         fi
         if [ "${{ inputs.mpi-wrapper-setup }}" == "oneapi" ]; then
           echo -e "CC=mpiicx\nCXX=mpiicpx\nFC=mpiifx" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -148,10 +148,10 @@ runs:
         bash -c "env > /tmp/before.txt"
         if [ "${{ inputs.compiler-setup }}" == "oneapi" ]; then
           echo -e "CC=icx\nCXX=icpx\nFC=ifx" >> $GITHUB_ENV
-          bash -c ". /opt/intel/oneapi/compiler/${{ inputs.oneapi-version }}/env/vars.sh && env >> /tmp/after.txt"
+          . /opt/intel/oneapi/compiler/${{ inputs.oneapi-version }}/env/vars.sh
         elif [ "${{ inputs.compiler-setup }}" == "classic" ]; then
           echo -e "CC=icc\nCXX=icpc\nFC=ifort" >> $GITHUB_ENV
-          bash -c ". /opt/intel/oneapi/compiler/${{ inputs.classic-version }}/env/vars.sh && env >> /tmp/after.txt"
+          . /opt/intel/oneapi/compiler/${{ inputs.classic-version }}/env/vars.sh
         fi
         if [ "${{ inputs.mpi-wrapper-setup }}" == "oneapi" ]; then
           echo -e "CC=mpiicx\nCXX=mpiicpx\nFC=mpiifx" >> $GITHUB_ENV
@@ -161,11 +161,12 @@ runs:
           echo -e "I_MPI_CC=icc\nI_MPI_CXX=icpc\nI_MPI_FC=ifort\nI_MPI_F77=ifort" >> $GITHUB_ENV
         fi
         if [ "${{ inputs.install-mkl }}" == true ]; then
-          bash -c ". /opt/intel/oneapi/mkl/${{ inputs.mkl-version }}/env/vars.sh && env >> /tmp/after.txt"
+          . /opt/intel/oneapi/mkl/${{ inputs.mkl-version }}/env/vars.sh
         fi
         echo "CI_INTEL_CLASSIC_VERSION=${{ inputs.classic-version }}" >> $GITHUB_ENV
         echo "CI_INTEL_ONEAPI_VERSION=${{ inputs.oneapi-version }}" >> $GITHUB_ENV
         echo "CI_INTEL_MPI_VERSION=${{ inputs.mpi-version }}" >> $GITHUB_ENV
         echo "CI_INTEL_MKL_VERSION=${{ inputs.mkl-version }}" >> $GITHUB_ENV
+        env > /tmp/after.txt
         diff --unchanged-line-format= --old-line-format= --new-line-format='%L' /tmp/before.txt /tmp/after.txt > /tmp/update.txt || true
         cat /tmp/update.txt |& tee -a $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -156,9 +156,11 @@ runs:
         if [ "${{ inputs.mpi-wrapper-setup }}" == "oneapi" ]; then
           echo -e "CC=mpiicx\nCXX=mpiicpx\nFC=mpiifx" >> $GITHUB_ENV
           echo -e "I_MPI_CC=icx\nI_MPI_CXX=icpx\nI_MPI_FC=ifx\nI_MPI_F77=ifx" >> $GITHUB_ENV
+          . /opt/intel/oneapi/mpi/${{ inputs.mpi-version }}/env/vars.sh
         elif [ "${{ inputs.mpi-wrapper-setup }}" == "classic" ]; then
           echo -e "CC=mpiicc\nCXX=mpiicpc\nFC=mpiifort" >> $GITHUB_ENV
           echo -e "I_MPI_CC=icc\nI_MPI_CXX=icpc\nI_MPI_FC=ifort\nI_MPI_F77=ifort" >> $GITHUB_ENV
+          . /opt/intel/oneapi/mpi/${{ inputs.mpi-version }}/env/vars.sh
         fi
         if [ "${{ inputs.install-mkl }}" == true ]; then
           . /opt/intel/oneapi/mkl/${{ inputs.mkl-version }}/env/vars.sh

--- a/ci/verify-mpi.sh
+++ b/ci/verify-mpi.sh
@@ -13,9 +13,9 @@ if [ "$COMPILER_TYPE" = "oneapi" ]; then
         which $compiler || { echo "ERROR: $compiler not found }
     done
     mpiicx --version
-    echo "CC=$CC (should be mpiicx)"
-    echo "CXX=$CXX (should be mpiicpx)"
-    echo "FC=$FC (should be mpiifx)"
+    echo "CC: $CC (should be mpiicx)"
+    echo "CXX: $CXX (should be mpiicpx)"
+    echo "FC: $FC (should be mpiifx)"
     test "$CC" = "mpiicx" || { echo "ERROR: CC should be mpiicx but is $CC"; exit 1; }
     test "$CXX" = "mpiicpx" || { echo "ERROR: CXX should be mpiicpx but is $CXX"; exit 1; }
     test "$FC" = "mpiifx" || { echo "ERROR: FC should be mpiifx but is $FC"; exit 1; }
@@ -24,9 +24,9 @@ else
         which $compiler || { echo "ERROR: $compiler not found }
     done
     mpiicc --version
-    echo "CC=$CC (should be mpiicc)"
-    echo "CXX=$CXX (should be mpiicpc)"
-    echo "FC=$FC (should be mpiifort)"
+    echo "CC: $CC (should be mpiicc)"
+    echo "CXX: $CXX (should be mpiicpc)"
+    echo "FC: $FC (should be mpiifort)"
     test "$CC" = "mpiicc" || { echo "ERROR: CC should be mpiicc but is $CC"; exit 1; }
     test "$CXX" = "mpiicpc" || { echo "ERROR: CXX should be mpiicpc but is $CXX"; exit 1; }
     test "$FC" = "mpiifort" || { echo "ERROR: FC should be mpiifort but is $FC"; exit 1; }

--- a/ci/verify-mpi.sh
+++ b/ci/verify-mpi.sh
@@ -2,16 +2,16 @@
 # Verify Intel MPI is installed and configured correctly
 # Usage: verify-mpi.sh [oneapi|classic]
 
-set -e
+set +e
 
 COMPILER_TYPE="${1:-oneapi}"
 
 echo "=== Checking MPI Installation (${COMPILER_TYPE}) ==="
 
 if [ "$COMPILER_TYPE" = "oneapi" ]; then
-    which mpiicx
-    which mpiicpx
-    which mpiifx
+    for compiler in mpiicx mpiicpx mpiifx; do
+        which $compiler || { echo "ERROR: $compiler not found }
+    done
     mpiicx --version
     echo "CC=$CC (should be mpiicx)"
     echo "CXX=$CXX (should be mpiicpx)"
@@ -20,9 +20,9 @@ if [ "$COMPILER_TYPE" = "oneapi" ]; then
     test "$CXX" = "mpiicpx" || { echo "ERROR: CXX should be mpiicpx but is $CXX"; exit 1; }
     test "$FC" = "mpiifx" || { echo "ERROR: FC should be mpiifx but is $FC"; exit 1; }
 else
-    which mpiicc
-    which mpiicpc
-    which mpiifort
+    for compiler in mpiicc mpiicx mpiifort; do
+        which $compiler || { echo "ERROR: $compiler not found }
+    done
     mpiicc --version
     echo "CC=$CC (should be mpiicc)"
     echo "CXX=$CXX (should be mpiicpc)"

--- a/ci/verify-mpi.sh
+++ b/ci/verify-mpi.sh
@@ -13,9 +13,9 @@ if [ "$COMPILER_TYPE" = "oneapi" ]; then
         which $compiler || { echo "ERROR: $compiler not found }
     done
     mpiicx --version
-    echo "CC: $CC (should be mpiicx)"
-    echo "CXX: $CXX (should be mpiicpx)"
-    echo "FC: $FC (should be mpiifx)"
+    echo "CC: $CC , should be mpiicx"
+    echo "CXX: $CXX , should be mpiicpx"
+    echo "FC: $FC , should be mpiifx"
     test "$CC" = "mpiicx" || { echo "ERROR: CC should be mpiicx but is $CC"; exit 1; }
     test "$CXX" = "mpiicpx" || { echo "ERROR: CXX should be mpiicpx but is $CXX"; exit 1; }
     test "$FC" = "mpiifx" || { echo "ERROR: FC should be mpiifx but is $FC"; exit 1; }
@@ -24,9 +24,9 @@ else
         which $compiler || { echo "ERROR: $compiler not found }
     done
     mpiicc --version
-    echo "CC: $CC (should be mpiicc)"
-    echo "CXX: $CXX (should be mpiicpc)"
-    echo "FC: $FC (should be mpiifort)"
+    echo "CC: $CC , should be mpiicc"
+    echo "CXX: $CXX , should be mpiicpc"
+    echo "FC: $FC , should be mpiifort"
     test "$CC" = "mpiicc" || { echo "ERROR: CC should be mpiicc but is $CC"; exit 1; }
     test "$CXX" = "mpiicpc" || { echo "ERROR: CXX should be mpiicpc but is $CXX"; exit 1; }
     test "$FC" = "mpiifort" || { echo "ERROR: FC should be mpiifort but is $FC"; exit 1; }

--- a/ci/verify-mpi.sh
+++ b/ci/verify-mpi.sh
@@ -10,7 +10,7 @@ echo "=== Checking MPI Installation (${COMPILER_TYPE}) ==="
 
 if [ "$COMPILER_TYPE" = "oneapi" ]; then
     for compiler in mpiicx mpiicpx mpiifx; do
-        which $compiler || { echo "ERROR: $compiler not found }
+        which $compiler || { echo "ERROR: $compiler not found" }
     done
     mpiicx --version
     echo "CC: $CC , should be mpiicx"
@@ -21,7 +21,7 @@ if [ "$COMPILER_TYPE" = "oneapi" ]; then
     test "$FC" = "mpiifx" || { echo "ERROR: FC should be mpiifx but is $FC"; exit 1; }
 else
     for compiler in mpiicc mpiicx mpiifort; do
-        which $compiler || { echo "ERROR: $compiler not found }
+        which $compiler || { echo "ERROR: $compiler not found" }
     done
     mpiicc --version
     echo "CC: $CC , should be mpiicc"

--- a/ci/verify-mpi.sh
+++ b/ci/verify-mpi.sh
@@ -10,7 +10,7 @@ echo "=== Checking MPI Installation (${COMPILER_TYPE}) ==="
 
 if [ "$COMPILER_TYPE" = "oneapi" ]; then
     for compiler in mpiicx mpiicpx mpiifx; do
-        which $compiler || { echo "ERROR: $compiler not found" }
+        which $compiler || { echo "ERROR: $compiler not found"; }
     done
     mpiicx --version
     echo "CC: $CC , should be mpiicx"
@@ -21,7 +21,7 @@ if [ "$COMPILER_TYPE" = "oneapi" ]; then
     test "$FC" = "mpiifx" || { echo "ERROR: FC should be mpiifx but is $FC"; exit 1; }
 else
     for compiler in mpiicc mpiicx mpiifort; do
-        which $compiler || { echo "ERROR: $compiler not found" }
+        which $compiler || { echo "ERROR: $compiler not found"; }
     done
     mpiicc --version
     echo "CC: $CC , should be mpiicc"


### PR DESCRIPTION
Instead of using the general setvars.sh script, which is tricky, source the component+version-specific vars.sh script.

Fixes verify-mpi.sh

Fixes #6